### PR TITLE
Support urfave/cli v3 --generate-shell-completion

### DIFF
--- a/cmd/carapace-bridge/cmd/root.go
+++ b/cmd/carapace-bridge/cmd/root.go
@@ -35,6 +35,7 @@ func Execute(version string) error {
 	rootCmd.Version = version
 	return rootCmd.Execute()
 }
+
 func init() {
 	carapace.Gen(rootCmd)
 	rootCmd.AddGroup(&cobra.Group{ID: "bridge", Title: "Bridge Commands"})
@@ -52,7 +53,8 @@ func init() {
 	addSubCommand("kingpin", "bridges https://github.com/alecthomas/kingpin", bridge.ActionKingpin)
 	addSubCommand("macro", "bridges macros exposed with https://github.com/carapace-sh/carapace-spec", bridge.ActionMacro)
 	addSubCommand("powershell", "bridges completions registered in powershell", bridge.ActionPowershell)
-	addSubCommand("urfavecli", "bridges https://github.com/urfave/cli", bridge.ActionUrfavecli)
+	addSubCommand("urfavecli", "bridges https://github.com/urfave/cli (v2)", bridge.ActionUrfavecli)
+	addSubCommand("urfavecliv3", "bridges https://github.com/urfave/cli (v3)", bridge.ActionUrfavecliV3)
 	addSubCommand("yargs", "bridges https://github.com/yargs/yargs", bridge.ActionYargs)
 	addSubCommand("zsh", "bridges completions registered in zsh", bridge.ActionZsh)
 }

--- a/pkg/actions/bridge/urfavecli.go
+++ b/pkg/actions/bridge/urfavecli.go
@@ -6,13 +6,31 @@ import (
 	"github.com/carapace-sh/carapace"
 )
 
-// ActionUrfavecli bridges https://github.com/urfave/cli
+// ActionUrfavecli bridges https://github.com/urfave/cli (v2)
 func ActionUrfavecli(command ...string) carapace.Action {
 	return actionCommand(command...)(func(command ...string) carapace.Action {
 		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
 			args := append(command[1:], c.Args...)
 			args = append(args, c.Value)
 			args = append(args, "--generate-bash-completion")
+			return carapace.ActionExecCommand(command[0], args...)(func(output []byte) carapace.Action {
+				lines := strings.Split(string(output), "\n")
+				if len(lines) <= 1 {
+					return carapace.ActionFiles()
+				}
+				return carapace.ActionValues(lines[:len(lines)-1]...).NoSpace([]rune("/=@:.,")...)
+			})
+		})
+	})
+}
+
+// ActionUrfavecliv3 bridges https://github.com/urfave/cli (v3)
+func ActionUrfavecliV3(command ...string) carapace.Action {
+	return actionCommand(command...)(func(command ...string) carapace.Action {
+		return carapace.ActionCallback(func(c carapace.Context) carapace.Action {
+			args := append(command[1:], c.Args...)
+			args = append(args, c.Value)
+			args = append(args, "--generate-shell-completion")
 			return carapace.ActionExecCommand(command[0], args...)(func(output []byte) carapace.Action {
 				lines := strings.Split(string(output), "\n")
 				if len(lines) <= 1 {


### PR DESCRIPTION
The existing bridge cannot be used with v3, as it exposes `--generate-shell-completion` instead of `--generate-bash-completion`

Would love to get some help on how to actually test this. How can I get my carapace to recognize `urfavecliv3` in e.g. `bridges.yaml` in a local dev setup?