### PR TITLE
bridge: added `kitten` identifier

### DIFF
--- a/pkg/actions/bridge/bridge.go
+++ b/pkg/actions/bridge/bridge.go
@@ -20,6 +20,7 @@ var bridgeActions = map[string]func(command ...string) carapace.Action{
 	"fish":           ActionFish,
 	"inshellisense":  ActionInshellisense,
 	"kingpin":        ActionKingpin,
+	"kitten":         ActionKitten,
 	"powershell":     ActionPowershell,
 	"urfavecli":      ActionUrfavecli,
 	"urfavecli@v1":   ActionUrfavecliV1,


### PR DESCRIPTION
related carapace-sh/carapace-bin#2877