### PR TITLE
fix(urfavecli): handle name:description formatting

### DIFF
--- a/pkg/actions/bridge/urfavecli.go
+++ b/pkg/actions/bridge/urfavecli.go
@@ -17,6 +17,7 @@ func actionUrfavecliV3(command ...string) carapace.Action {
 			args := append(command[1:], c.Args...)
 			args = append(args, c.Value)
 			args = append(args, "--generate-shell-completion")
+			c.Setenv("SHELL", "zsh")
 			return carapace.ActionExecCommand(command[0], args...)(func(output []byte) carapace.Action {
 				lines := strings.Split(string(output), "\n")
 				if len(lines) <= 1 {
@@ -30,7 +31,7 @@ func actionUrfavecliV3(command ...string) carapace.Action {
 					}
 				}
 				return carapace.ActionValuesDescribed(vals...).NoSpace([]rune("/=@:.,")...)
-			})
+			}).Invoke(c).ToA()
 		})
 	})
 }

--- a/pkg/actions/bridge/urfavecli.go
+++ b/pkg/actions/bridge/urfavecli.go
@@ -22,7 +22,14 @@ func actionUrfavecliV3(command ...string) carapace.Action {
 				if len(lines) <= 1 {
 					return carapace.ActionFiles()
 				}
-				return carapace.ActionValues(lines[:len(lines)-1]...).NoSpace([]rune("/=@:.,")...)
+				vals := make([]string, 0)
+				for _, line := range lines {
+					if line != "" {
+						name, description, _ := strings.Cut(line, ":")
+						vals = append(vals, name, description)
+					}
+				}
+				return carapace.ActionValuesDescribed(vals...).NoSpace([]rune("/=@:.,")...)
 			})
 		})
 	})


### PR DESCRIPTION
Finally got to try this a bit more and noticed I got full `name:description` completions returned when pressing TAB. 
I took the approach from yargs to split and return `ActionValuesDescribed`.
Not sure about urfavecli v1 and v2, and why this has not come up in the past, so I haven't touched that one.